### PR TITLE
Dodanie demona zdrowia i CLI

### DIFF
--- a/PiRout/.gitignore
+++ b/PiRout/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+venv/

--- a/PiRout/api/requirements.txt
+++ b/PiRout/api/requirements.txt
@@ -1,2 +1,4 @@
 Flask==3.0.0
 pytest==8.1.1
+typer==0.12.3
+psutil==5.9.8

--- a/PiRout/backend/python/pirout/__init__.py
+++ b/PiRout/backend/python/pirout/__init__.py
@@ -1,2 +1,7 @@
 """Moduł inicjujący PiRout."""
-__all__ = []
+
+__all__ = [
+    'health_daemon',
+    'snapshot_manager',
+    'cli',
+]

--- a/PiRout/backend/python/pirout/__main__.py
+++ b/PiRout/backend/python/pirout/__main__.py
@@ -1,0 +1,4 @@
+from .cli import app
+
+if __name__ == '__main__':
+    app()

--- a/PiRout/backend/python/pirout/cli.py
+++ b/PiRout/backend/python/pirout/cli.py
@@ -1,0 +1,38 @@
+import datetime
+from pathlib import Path
+import subprocess
+
+import psutil
+import typer
+
+app = typer.Typer(help="Narzędzie CLI PiRout")
+
+
+@app.callback()
+def main() -> None:
+    """Główne polecenie."""
+    pass
+
+
+@app.command()
+def doctor(zapisz: Path = typer.Option(None, help="Plik na raport")) -> None:
+    """Diagnostyka łączności i obciążenia."""
+    raport = [f"# Raport PiRout {datetime.datetime.now().isoformat()}\n"]
+    wynik = subprocess.run(["ping", "-c", "1", "8.8.8.8"], capture_output=True)
+    if wynik.returncode == 0:
+        raport.append("## Łączność: OK\n")
+    else:
+        raport.append("## Łączność: BŁĄD\n")
+        raport.append("``\n" + wynik.stderr.decode() + "\n``\n")
+    cpu = psutil.cpu_percent(interval=1)
+    raport.append(f"## Użycie CPU: {cpu}%\n")
+    tresc = "\n".join(raport)
+    if zapisz:
+        Path(zapisz).write_text(tresc)
+        typer.echo(f"Raport zapisano w {zapisz}")
+    else:
+        typer.echo(tresc)
+
+
+if __name__ == "__main__":
+    app()

--- a/PiRout/backend/python/pirout/config_manager.py
+++ b/PiRout/backend/python/pirout/config_manager.py
@@ -2,8 +2,18 @@
 from pathlib import Path
 import os
 
+
 KATALOG_KONFIG = Path(os.getenv("PIR_OUT_CONF", "/etc/pirout"))
+
 
 def pobierz_sciezke(plik: str) -> Path:
     """Zwraca pełną ścieżkę do pliku konfiguracyjnego."""
     return KATALOG_KONFIG / plik
+
+
+def zapisz(plik: str, dane: str, opis: str) -> None:
+    sciezka = pobierz_sciezke(plik)
+    sciezka.parent.mkdir(parents=True, exist_ok=True)
+    sciezka.write_text(dane)
+    from . import snapshot_manager
+    snapshot_manager.zapisz_snapshot(opis)

--- a/PiRout/backend/python/pirout/health_daemon.py
+++ b/PiRout/backend/python/pirout/health_daemon.py
@@ -1,0 +1,45 @@
+import logging
+import subprocess
+import time
+from pathlib import Path
+
+# Konfiguracja logowania
+LOG_FILE = Path('/var/log/pirout-health.log')
+logging.basicConfig(filename=LOG_FILE, level=logging.INFO,
+                    format='%(asctime)s %(levelname)s: %(message)s')
+
+# Definicje modułów do monitorowania
+MODULY = {
+    'openvpn': {
+        'proces': 'openvpn',
+        'restart': ['./backend/bash-scripts/openvpn_manager.sh', 'start'],
+    },
+    'wireguard': {
+        'proces': 'wg-quick',
+        'restart': ['./backend/bash-scripts/wireguard_manager.sh', 'start'],
+    },
+    'zapora': {
+        'proces': 'nft',
+        'restart': ['./backend/bash-scripts/firewall.sh', 'start'],
+    },
+}
+
+
+def sprawdz_modul(nazwa: str, dane: dict) -> None:
+    if subprocess.run(['pgrep', dane['proces']], capture_output=True).returncode != 0:
+        logging.warning('Moduł %s nie działa, restart...', nazwa)
+        subprocess.run(dane['restart'], check=False)
+    else:
+        logging.info('Moduł %s działa prawidłowo', nazwa)
+
+
+def main() -> None:
+    logging.info('Uruchomiono daemon zdrowotny')
+    while True:
+        for nazwa, dane in MODULY.items():
+            sprawdz_modul(nazwa, dane)
+        time.sleep(30)
+
+
+if __name__ == '__main__':
+    main()

--- a/PiRout/backend/python/pirout/snapshot_manager.py
+++ b/PiRout/backend/python/pirout/snapshot_manager.py
@@ -1,0 +1,52 @@
+"""Zarządzanie migawkami konfiguracji."""
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+from .config_manager import KATALOG_KONFIG
+
+KATALOG_SNAP = Path(os.getenv('PIR_OUT_SNAPSHOTS', '/var/lib/pirout/snapshots'))
+
+
+def _inicjuj_repo() -> None:
+    if not (KATALOG_SNAP / '.git').exists():
+        KATALOG_SNAP.mkdir(parents=True, exist_ok=True)
+        subprocess.run(['git', 'init'], cwd=KATALOG_SNAP, check=True)
+
+
+def _skopiuj_konfiguracje() -> None:
+    for element in KATALOG_SNAP.iterdir():
+        if element.name == '.git':
+            continue
+        if element.is_file():
+            element.unlink()
+        else:
+            shutil.rmtree(element)
+    for src in KATALOG_KONFIG.iterdir():
+        dest = KATALOG_SNAP / src.name
+        if src.is_file():
+            shutil.copy2(src, dest)
+        else:
+            shutil.copytree(src, dest)
+
+
+def zapisz_snapshot(opis: str) -> None:
+    _inicjuj_repo()
+    _skopiuj_konfiguracje()
+    subprocess.run(['git', 'add', '-A'], cwd=KATALOG_SNAP, check=True)
+    subprocess.run(['git', 'commit', '-m', opis], cwd=KATALOG_SNAP, check=True)
+
+
+def rollback(commit_id: str) -> None:
+    subprocess.run(['git', 'checkout', commit_id, '--', '.'], cwd=KATALOG_SNAP, check=True)
+    for src in KATALOG_SNAP.iterdir():
+        if src.name == '.git':
+            continue
+        dest = KATALOG_KONFIG / src.name
+        if src.is_file():
+            shutil.copy2(src, dest)
+        else:
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(src, dest)

--- a/PiRout/backend/python/tests/test_cli_snapshot.py
+++ b/PiRout/backend/python/tests/test_cli_snapshot.py
@@ -1,0 +1,31 @@
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.append(str(ROOT / "backend" / "python"))
+
+from pirout import config_manager  # noqa: E402
+
+
+def test_doctor() -> None:
+    wynik = subprocess.run([
+        sys.executable,
+        "-m",
+        "pirout",
+        "doctor",
+    ], capture_output=True, text=True)
+    assert "Raport PiRout" in wynik.stdout
+
+
+def test_snapshot(tmp_path, monkeypatch) -> None:
+    konf = tmp_path / "conf"
+    snap = tmp_path / "snap"
+    monkeypatch.setenv("PIR_OUT_CONF", str(konf))
+    monkeypatch.setenv("PIR_OUT_SNAPSHOTS", str(snap))
+    konf.mkdir()
+    snap.mkdir()
+    subprocess.run(["git", "init"], cwd=snap, check=True)
+    config_manager.zapisz("test.conf", "dane", "inicjalny")
+    historia = subprocess.run(["git", "log", "--oneline"], cwd=snap, capture_output=True, text=True)
+    assert "inicjalny" in historia.stdout

--- a/PiRout/backend/systemd/pirout-health.service
+++ b/PiRout/backend/systemd/pirout-health.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=PiRout Health Check Daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /opt/pirout/health_daemon.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Podsumowanie
- implementacja demona health-check
- snapshoty konfiguracji wraz z rollbackiem
- CLI `pirout doctor`
- testy dla nowych modułów

## Testy
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6868bdc007e48330a19ff8cccdb6470f