### PR TITLE
Dodanie komendy snapshot-list i testów zapory

### DIFF
--- a/PiRout/README.md
+++ b/PiRout/README.md
@@ -15,6 +15,11 @@ make run
 make test
 ```
 
+## Lista migawek
+```
+python -m pirout snapshot-list
+```
+
 ## Lint
 ```
 make lint

--- a/PiRout/README.md
+++ b/PiRout/README.md
@@ -20,6 +20,11 @@ make test
 python -m pirout snapshot-list
 ```
 
+## Status zapory
+```
+python -m pirout firewall-status
+```
+
 ## Lint
 ```
 make lint

--- a/PiRout/api/app.py
+++ b/PiRout/api/app.py
@@ -1,22 +1,27 @@
 from flask import Flask, jsonify
 from backend.python.pirout.firewall_manager import MenedzerZapory
 
+
 app = Flask(__name__)
 zapora = MenedzerZapory()
+
 
 @app.route("/status")
 def status() -> tuple:
     return jsonify({"status": "ok"})
+
 
 @app.route("/firewall/start", methods=["POST"])
 def firewall_start() -> tuple:
     zapora.wlacz()
     return jsonify({"firewall": "wlaczona"})
 
+
 @app.route("/firewall/stop", methods=["POST"])
 def firewall_stop() -> tuple:
     zapora.wylacz()
     return jsonify({"firewall": "wylaczona"})
+
 
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)

--- a/PiRout/api/app.py
+++ b/PiRout/api/app.py
@@ -23,5 +23,11 @@ def firewall_stop() -> tuple:
     return jsonify({"firewall": "wylaczona"})
 
 
+@app.route("/firewall/status")
+def firewall_status_api() -> tuple:
+    aktywna = zapora.status()
+    return jsonify({"firewall": "aktywna" if aktywna else "wylaczona"})
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0", port=5000)

--- a/PiRout/backend/python/pirout/cli.py
+++ b/PiRout/backend/python/pirout/cli.py
@@ -1,4 +1,5 @@
 import datetime
+import os
 from pathlib import Path
 import subprocess
 
@@ -32,6 +33,22 @@ def doctor(zapisz: Path = typer.Option(None, help="Plik na raport")) -> None:
         typer.echo(f"Raport zapisano w {zapisz}")
     else:
         typer.echo(tresc)
+
+
+@app.command("snapshot-list")
+def snapshot_list() -> None:
+    """Wyświetla historię migawek konfiguracji."""
+    repo = Path(os.getenv("PIR_OUT_SNAPSHOTS", "/var/lib/pirout/snapshots"))
+    if not (repo / ".git").exists():
+        typer.echo("Brak migawek")
+        raise typer.Exit()
+    wynik = subprocess.run(
+        ["git", "-C", str(repo), "log", "--oneline"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    typer.echo(wynik.stdout)
 
 
 if __name__ == "__main__":

--- a/PiRout/backend/python/pirout/cli.py
+++ b/PiRout/backend/python/pirout/cli.py
@@ -6,6 +6,8 @@ import subprocess
 import psutil
 import typer
 
+from .firewall_manager import MenedzerZapory
+
 app = typer.Typer(help="Narzędzie CLI PiRout")
 
 
@@ -49,6 +51,15 @@ def snapshot_list() -> None:
         check=True,
     )
     typer.echo(wynik.stdout)
+
+
+@app.command("firewall-status")
+def firewall_status() -> None:
+    """Sprawdza stan zapory."""
+    menedzer = MenedzerZapory()
+    aktywna = menedzer.status()
+    stan = "aktywna" if aktywna else "wylaczona"
+    typer.echo(f"Zapora {stan}")
 
 
 if __name__ == "__main__":

--- a/PiRout/backend/python/pirout/dns_manager.py
+++ b/PiRout/backend/python/pirout/dns_manager.py
@@ -1,6 +1,10 @@
 """Menedżer DNS."""
+
 import subprocess
 
+
 class MenedzerDns:
+    """Zarządzanie adresami DNS."""
+
     def ustaw_dns(self, adres: str) -> None:
         subprocess.run(["resolvectl", "dns", "eth0", adres], check=True)

--- a/PiRout/backend/python/pirout/failover_manager.py
+++ b/PiRout/backend/python/pirout/failover_manager.py
@@ -1,6 +1,13 @@
 """Menedżer failover."""
+
 import subprocess
 
+
 class MenedzerFailover:
+    """Ustawia zapasową bramę."""
+
     def ustaw(self, brama: str) -> None:
-        subprocess.run(["./backend/bash-scripts/failover.sh", brama], check=True)
+        subprocess.run(
+            ["./backend/bash-scripts/failover.sh", brama],
+            check=True,
+        )

--- a/PiRout/backend/python/pirout/firewall_manager.py
+++ b/PiRout/backend/python/pirout/firewall_manager.py
@@ -1,11 +1,19 @@
 """Menedżer zapory sieciowej."""
+
 import subprocess
+
 
 class MenedzerZapory:
     """Klasa do zarządzania zaporą."""
 
+    SKRYPT = "./backend/bash-scripts/firewall.sh"
+
     def wlacz(self) -> None:
-        subprocess.run(["./backend/bash-scripts/firewall.sh", "start"], check=True)
+        subprocess.run([self.SKRYPT, "start"], check=True)
 
     def wylacz(self) -> None:
-        subprocess.run(["./backend/bash-scripts/firewall.sh", "stop"], check=True)
+        subprocess.run([self.SKRYPT, "stop"], check=True)
+
+    def status(self) -> bool:
+        wynik = subprocess.run(["iptables", "-L"], capture_output=True)
+        return wynik.returncode == 0

--- a/PiRout/backend/python/pirout/health_daemon.py
+++ b/PiRout/backend/python/pirout/health_daemon.py
@@ -5,8 +5,11 @@ from pathlib import Path
 
 # Konfiguracja logowania
 LOG_FILE = Path('/var/log/pirout-health.log')
-logging.basicConfig(filename=LOG_FILE, level=logging.INFO,
-                    format='%(asctime)s %(levelname)s: %(message)s')
+logging.basicConfig(
+    filename=LOG_FILE,
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s: %(message)s',
+)
 
 # Definicje modułów do monitorowania
 MODULY = {
@@ -26,7 +29,11 @@ MODULY = {
 
 
 def sprawdz_modul(nazwa: str, dane: dict) -> None:
-    if subprocess.run(['pgrep', dane['proces']], capture_output=True).returncode != 0:
+    wynik = subprocess.run(
+        ['pgrep', dane['proces']],
+        capture_output=True,
+    )
+    if wynik.returncode != 0:
         logging.warning('Moduł %s nie działa, restart...', nazwa)
         subprocess.run(dane['restart'], check=False)
     else:

--- a/PiRout/backend/python/pirout/ikev2_manager.py
+++ b/PiRout/backend/python/pirout/ikev2_manager.py
@@ -1,6 +1,10 @@
 """Menedżer IKEv2."""
+
 from .vpn_manager import MenedzerVPN
 
+
 class MenedzerIkev2(MenedzerVPN):
+    """Obsługa tunelu IKEv2."""
+
     def __init__(self) -> None:
         super().__init__("./backend/bash-scripts/ikev2_manager.sh")

--- a/PiRout/backend/python/pirout/l2tp_manager.py
+++ b/PiRout/backend/python/pirout/l2tp_manager.py
@@ -1,6 +1,10 @@
 """Menedżer L2TP."""
+
 from .vpn_manager import MenedzerVPN
 
+
 class MenedzerL2tp(MenedzerVPN):
+    """Obsługa tunelu L2TP."""
+
     def __init__(self) -> None:
         super().__init__("./backend/bash-scripts/l2tp_manager.sh")

--- a/PiRout/backend/python/pirout/pptp_manager.py
+++ b/PiRout/backend/python/pirout/pptp_manager.py
@@ -1,6 +1,10 @@
 """Menedżer PPTP."""
+
 from .vpn_manager import MenedzerVPN
 
+
 class MenedzerPptp(MenedzerVPN):
+    """Obsługa tunelu PPTP."""
+
     def __init__(self) -> None:
         super().__init__("./backend/bash-scripts/pptp_manager.sh")

--- a/PiRout/backend/python/pirout/routing_manager.py
+++ b/PiRout/backend/python/pirout/routing_manager.py
@@ -1,6 +1,13 @@
 """Menedżer tras."""
+
 import subprocess
 
+
 class MenedzerTrasy:
+    """Zarządzanie trasami sieci."""
+
     def dodaj_trase(self, siec: str, brama: str) -> None:
-        subprocess.run(["./backend/bash-scripts/routing.sh", siec, brama], check=True)
+        subprocess.run(
+            ["./backend/bash-scripts/routing.sh", siec, brama],
+            check=True,
+        )

--- a/PiRout/backend/python/pirout/security_manager.py
+++ b/PiRout/backend/python/pirout/security_manager.py
@@ -1,9 +1,19 @@
 """Menedżer bezpieczeństwa."""
+
 import subprocess
 
+
 class MenedzerBezpieczenstwa:
+    """Zarządza parametrami bezpieczeństwa."""
+
     def wylacz_icmp(self) -> None:
-        subprocess.run(["sysctl", "-w", "net.ipv4.icmp_echo_ignore_all=1"], check=True)
+        subprocess.run(
+            ["sysctl", "-w", "net.ipv4.icmp_echo_ignore_all=1"],
+            check=True,
+        )
 
     def wlacz_icmp(self) -> None:
-        subprocess.run(["sysctl", "-w", "net.ipv4.icmp_echo_ignore_all=0"], check=True)
+        subprocess.run(
+            ["sysctl", "-w", "net.ipv4.icmp_echo_ignore_all=0"],
+            check=True,
+        )

--- a/PiRout/backend/python/pirout/snapshot_manager.py
+++ b/PiRout/backend/python/pirout/snapshot_manager.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 from .config_manager import KATALOG_KONFIG
 
-KATALOG_SNAP = Path(os.getenv('PIR_OUT_SNAPSHOTS', '/var/lib/pirout/snapshots'))
+KATALOG_SNAP = Path(
+    os.getenv('PIR_OUT_SNAPSHOTS', '/var/lib/pirout/snapshots')
+)
 
 
 def _inicjuj_repo() -> None:
@@ -35,11 +37,19 @@ def zapisz_snapshot(opis: str) -> None:
     _inicjuj_repo()
     _skopiuj_konfiguracje()
     subprocess.run(['git', 'add', '-A'], cwd=KATALOG_SNAP, check=True)
-    subprocess.run(['git', 'commit', '-m', opis], cwd=KATALOG_SNAP, check=True)
+    subprocess.run(
+        ['git', 'commit', '-m', opis],
+        cwd=KATALOG_SNAP,
+        check=True,
+    )
 
 
 def rollback(commit_id: str) -> None:
-    subprocess.run(['git', 'checkout', commit_id, '--', '.'], cwd=KATALOG_SNAP, check=True)
+    subprocess.run(
+        ['git', 'checkout', commit_id, '--', '.'],
+        cwd=KATALOG_SNAP,
+        check=True,
+    )
     for src in KATALOG_SNAP.iterdir():
         if src.name == '.git':
             continue

--- a/PiRout/backend/python/pirout/vpn_manager.py
+++ b/PiRout/backend/python/pirout/vpn_manager.py
@@ -1,5 +1,7 @@
 """Podstawowa klasa zarządzająca usługami VPN."""
+
 import subprocess
+
 
 class MenedzerVPN:
     """Bazowy menedżer VPN."""

--- a/PiRout/backend/python/pirout/wireguard_manager.py
+++ b/PiRout/backend/python/pirout/wireguard_manager.py
@@ -1,6 +1,10 @@
 """Menedżer WireGuarda."""
+
 from .vpn_manager import MenedzerVPN
 
+
 class MenedzerWireguard(MenedzerVPN):
+    """Obsługa tunelu WireGuard."""
+
     def __init__(self) -> None:
         super().__init__("./backend/bash-scripts/wireguard_manager.sh")

--- a/PiRout/backend/python/tests/test_app.py
+++ b/PiRout/backend/python/tests/test_app.py
@@ -2,10 +2,11 @@ import json
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT))
 
 import api.app as api_app  # noqa: E402
+
 
 def test_status():
     klient = api_app.app.test_client()
@@ -34,3 +35,11 @@ def test_firewall_stop(monkeypatch):
     dane = json.loads(odp.data)
     assert dane['firewall'] == 'wylaczona'
     assert akcje == ['stop']
+
+
+def test_firewall_status(monkeypatch):
+    monkeypatch.setattr(api_app.zapora, 'status', lambda: True)
+    klient = api_app.app.test_client()
+    odp = klient.get('/firewall/status')
+    dane = json.loads(odp.data)
+    assert dane['firewall'] == 'aktywna'

--- a/PiRout/backend/python/tests/test_app.py
+++ b/PiRout/backend/python/tests/test_app.py
@@ -5,10 +5,32 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 sys.path.append(str(ROOT))
 
-from api.app import app  # noqa: E402
+import api.app as api_app  # noqa: E402
 
 def test_status():
-    klient = app.test_client()
+    klient = api_app.app.test_client()
     odp = klient.get('/status')
     dane = json.loads(odp.data)
     assert dane['status'] == 'ok'
+
+
+def test_firewall_start(monkeypatch):
+    akcje = []
+    monkeypatch.setattr(api_app, 'zapora', api_app.zapora)
+    monkeypatch.setattr(api_app.zapora, 'wlacz', lambda: akcje.append('start'))
+    klient = api_app.app.test_client()
+    odp = klient.post('/firewall/start')
+    dane = json.loads(odp.data)
+    assert dane['firewall'] == 'wlaczona'
+    assert akcje == ['start']
+
+
+def test_firewall_stop(monkeypatch):
+    akcje = []
+    monkeypatch.setattr(api_app, 'zapora', api_app.zapora)
+    monkeypatch.setattr(api_app.zapora, 'wylacz', lambda: akcje.append('stop'))
+    klient = api_app.app.test_client()
+    odp = klient.post('/firewall/stop')
+    dane = json.loads(odp.data)
+    assert dane['firewall'] == 'wylaczona'
+    assert akcje == ['stop']

--- a/PiRout/backend/python/tests/test_cli_snapshot.py
+++ b/PiRout/backend/python/tests/test_cli_snapshot.py
@@ -1,20 +1,26 @@
-import subprocess
+import os
 import sys
+import subprocess
 from pathlib import Path
+from typer.testing import CliRunner
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.append(str(ROOT / "backend" / "python"))
 
+from pirout.cli import app  # noqa: E402
 from pirout import config_manager  # noqa: E402
 
+runner = CliRunner()
 
-def test_doctor() -> None:
-    wynik = subprocess.run([
-        sys.executable,
-        "-m",
-        "pirout",
-        "doctor",
-    ], capture_output=True, text=True)
+
+def test_doctor(monkeypatch) -> None:
+    def fake_run(*args, **kwargs):
+        class R:
+            returncode = 0
+            stderr = b""
+        return R()
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    wynik = runner.invoke(app, ["doctor"])
     assert "Raport PiRout" in wynik.stdout
 
 
@@ -25,24 +31,28 @@ def test_snapshot(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("PIR_OUT_SNAPSHOTS", str(snap))
     konf.mkdir()
     snap.mkdir()
-    subprocess.run(["git", "init"], cwd=snap, check=True)
+    os.system(f"git init {snap}")
     config_manager.zapisz("test.conf", "dane", "inicjalny")
-    historia = subprocess.run(["git", "log", "--oneline"], cwd=snap, capture_output=True, text=True)
-    assert "inicjalny" in historia.stdout
+    log = os.popen(f"git -C {snap} log --oneline").read()
+    assert "inicjalny" in log
 
 
 def test_snapshot_list(tmp_path, monkeypatch) -> None:
     repo = tmp_path / "snap"
     monkeypatch.setenv("PIR_OUT_SNAPSHOTS", str(repo))
     repo.mkdir()
-    subprocess.run(["git", "init"], cwd=repo, check=True)
+    os.system(f"git init {repo}")
     (repo / "plik").write_text("d")
-    subprocess.run(["git", "add", "plik"], cwd=repo, check=True)
-    subprocess.run(["git", "commit", "-m", "start"], cwd=repo, check=True)
-    wynik = subprocess.run([
-        sys.executable,
-        "-m",
-        "pirout",
-        "snapshot-list",
-    ], capture_output=True, text=True)
+    os.system(f"git -C {repo} add plik")
+    os.system(f"git -C {repo} commit -m start")
+    wynik = runner.invoke(app, ["snapshot-list"])
     assert "start" in wynik.stdout
+
+
+def test_firewall_status_cli(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "pirout.firewall_manager.MenedzerZapory.status",
+        lambda self: True,
+    )
+    wynik = runner.invoke(app, ["firewall-status"])
+    assert "aktywna" in wynik.stdout

--- a/PiRout/backend/python/tests/test_cli_snapshot.py
+++ b/PiRout/backend/python/tests/test_cli_snapshot.py
@@ -29,3 +29,20 @@ def test_snapshot(tmp_path, monkeypatch) -> None:
     config_manager.zapisz("test.conf", "dane", "inicjalny")
     historia = subprocess.run(["git", "log", "--oneline"], cwd=snap, capture_output=True, text=True)
     assert "inicjalny" in historia.stdout
+
+
+def test_snapshot_list(tmp_path, monkeypatch) -> None:
+    repo = tmp_path / "snap"
+    monkeypatch.setenv("PIR_OUT_SNAPSHOTS", str(repo))
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    (repo / "plik").write_text("d")
+    subprocess.run(["git", "add", "plik"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-m", "start"], cwd=repo, check=True)
+    wynik = subprocess.run([
+        sys.executable,
+        "-m",
+        "pirout",
+        "snapshot-list",
+    ], capture_output=True, text=True)
+    assert "start" in wynik.stdout


### PR DESCRIPTION
## Podsumowanie
- rozbudowano `cli.py` o komendę `snapshot-list`
- dodano metodę `status` w `firewall_manager`
- poprawiono styl w modułach Pythona
- rozszerzono testy o sprawdzenie zapory oraz listy migawek
- uaktualniono dokumentację `README`

## Testy
- `flake8 backend/python/pirout api/app.py`
- `pytest backend/python`

------
https://chatgpt.com/codex/tasks/task_e_686980b3124c8330a9b4d2f81cdb933f